### PR TITLE
Show ellipsis in tab title when overflowing

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -131,19 +131,23 @@
   display: none;
 }
 
-.tab > .title {
+.tab > .titleHost {
   flex-grow: 1;
-  width: 0;
-  text-overflow: ellipsis;
-  overflow-x: hidden;
   z-index: 1000;
   opacity: 0.7;
   font: -moz-field;
   font-size: 12px;
 }
 
-.tab.selected > .title {
+.tab.selected > .titleHost {
   opacity: 1;
+}
+
+.tab > .titleHost > .title {
+  max-width: 94px;
+  width: inherit;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .tab > .close-button {

--- a/js/tab.js
+++ b/js/tab.js
@@ -21,7 +21,10 @@ function Tab(iframeParent) {
   let favicon = document.createElement("img");
   favicon.className = "favicon";
 
-  let title = document.createElement("hbox");
+  let titleHost = document.createElement("hbox");
+  titleHost.className = "titleHost";
+
+  let title = document.createElement("div");
   title.className = "title";
 
   let button = document.createElement("button");
@@ -33,8 +36,10 @@ function Tab(iframeParent) {
 
   hbox.appendChild(throbber);
   hbox.appendChild(favicon);
-  hbox.appendChild(title);
+  hbox.appendChild(titleHost);
   hbox.appendChild(button);
+
+  titleHost.appendChild(title);
 
   this.clearTabData();
 


### PR DESCRIPTION
This should address #36

The main change is wrapping the title in a host element.
There is probably more than one way to skin the cat on this, but I think this is a valid approach.

(I haven't done a PR before in my github life time but hopefully this is correct and helpful.)
