### PR TITLE
Focussing URL bar when a new tab is created.

### DIFF
--- a/js/navbar.js
+++ b/js/navbar.js
@@ -86,6 +86,11 @@ function(Cmds, UrlHelper, TabIframeDeck) {
     }
     lastSelectedTab = selectedTabIframe;
     if (selectedTabIframe) {
+      if (!selectedTabIframe.location) {
+        urlinput.focus();
+        urlinput.select();
+      }
+
       selectedTabIframe.on("dataUpdate", UpdateTab);
       UpdateTab();
     }


### PR DESCRIPTION
When 'createNewTab' is called, an extra option 'newTab' is passed. This helps in identifying new tab creation.

When a new tab is added to the TabIframeDeck, it checks if it has a 'newTab' option. If so, 'urlinput' is focussed and selected.
