### PR TITLE
Middle clicking a tab now closes it.

### DIFF
--- a/js/tab.js
+++ b/js/tab.js
@@ -44,6 +44,7 @@ require(['js/tabiframedeck'], function(TabIframeDeck) {
     hbox.onmousedown = (event) => {
       if(event.button == 1)
       {
+        event.stopPropagation();
         TabIframeDeck.remove(tabIframe);
       } else {
         TabIframeDeck.select(tabIframe);


### PR DESCRIPTION
Rather than only checking for a left click, any mouse-down event on a tab will be evaluated (also making it easier to also detect right-clicking a tab when needed in the future). If the button clicked was the middle mouse button, the tab will be closed.
