### PR TITLE
Middle clicking a tab now closes it.

### DIFF
--- a/js/tab.js
+++ b/js/tab.js
@@ -36,14 +36,25 @@ require(['js/tabiframedeck'], function(TabIframeDeck) {
     let button = document.createElement("button");
     button.className = "close-button";
 
-    button.onclick = (event) => {
-      event.stopPropagation();
-      TabIframeDeck.remove(tabIframe);
+    button.onmouseup = (event) => {
+      if(event.button == 0) {
+        event.stopPropagation();
+        TabIframeDeck.remove(tabIframe);
+      }
     };
 
-    hbox.onclick = (event) => {
-      TabIframeDeck.select(tabIframe);
+    hbox.onmousedown = (event) => {
+      if(event.button == 0) {
+        TabIframeDeck.select(tabIframe);
+      }
     };
+
+    hbox.onmouseup = (event) => {
+      if(event.button == 1) {
+        event.stopPropagation();
+        TabIframeDeck.remove(tabIframe);
+      }
+    }
 
     hbox.appendChild(throbber);
     hbox.appendChild(favicon);


### PR DESCRIPTION
Rather than only checking for a left click, any mouse-down event on a tab will be evaluated (also making it easier to also detect right-clicking a tab when needed in the future). If the button clicked was the middle mouse button, the tab will be closed.
