### PR TITLE
Make search input full width of the .searchbar.

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -287,6 +287,10 @@ body:not(.loading) .stop-button {
   min-width: 0;
 }
 
+.searchinput {
+  width: 100%;
+}
+
 .searchselector {
   width: 16px;
   height: 16px;


### PR DESCRIPTION
Previously, you were unable to focus the search input by clicking in the right portion of the search box because the input wasn't scaled to the full width of `.searchbar`.
