### PR TITLE
Added .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "0.10"


### PR DESCRIPTION
Hi @paulrouget,

as long as firefox.html isn't inside an organisation it looks like only the owner of the repository itself can enable Travis. You need to [login](https://travis-ci.org/) once and than activate Travis for this repo [here](https://travis-ci.org/profile). After that it should be safe to merge this pull request.

Note: Travis automatically calls `$ npm test` as this is the canonical way for running tests in Node. Therefor we only need to tell Travis which language (and version) we use.
