### PR TITLE
fine-tuned jscs rules

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -4,8 +4,110 @@
     "node_modules/**",
     "lib/**"
   ],
+  "requireSpaceBeforeKeywords": [
+    "else",
+    "while",
+    "catch"
+  ],
+  "requireSpaceAfterKeywords": [
+    "do",
+    "for",
+    "if",
+    "else",
+    "switch",
+    "case",
+    "try",
+    "catch",
+    "void",
+    "while",
+    "with",
+    "return",
+    "typeof"
+  ],
+  "requireSpaceBeforeBlockStatements": true,
+  "requireSpacesInConditionalExpression": true,
+  "requireSpacesInFunction": {
+    "beforeOpeningCurlyBrace": true
+  },
+  "disallowSpacesInFunction": {
+    "beforeOpeningRoundBrace": true
+  },
+  "disallowSpacesInCallExpression": true,
+  "disallowMultipleVarDecl": true,
+  "disallowSpacesInsideObjectBrackets": "all",
+  "disallowSpacesInsideArrayBrackets": "all",
+  "disallowSpacesInsideParentheses": true,
+  "disallowQuotedKeysInObjects": true,
+  "disallowSpaceAfterObjectKeys": true,
+  "requireCommaBeforeLineBreak": true,
+  "requireOperatorBeforeLineBreak": [
+    "?",
+    "=",
+    "+",
+    "-",
+    "/",
+    "*",
+    "==",
+    "===",
+    "!=",
+    "!==",
+    ">",
+    ">=",
+    "<",
+    "<="
+  ],
+  "disallowOperatorBeforeLineBreak": [
+    "."
+  ],
+  "disallowSpaceAfterPrefixUnaryOperators": [
+    "++",
+    "--",
+    "+",
+    "-",
+    "~",
+    "!"
+  ],
+  "disallowSpaceBeforePostfixUnaryOperators": [
+    "++",
+    "--"
+  ],
+  "disallowSpaceBeforeBinaryOperators": [
+    ","
+  ],
+  "requireSpaceBeforeBinaryOperators": [
+    "=",
+    "+",
+    "-",
+    "/",
+    "*",
+    "==",
+    "===",
+    "!=",
+    "!=="
+  ],
+  "requireSpaceAfterBinaryOperators": [
+    "=",
+    ",",
+    "+",
+    "-",
+    "/",
+    "*",
+    "==",
+    "===",
+    "!=",
+    "!=="
+  ],
+  "disallowMixedSpacesAndTabs": true,
+  "disallowTrailingWhitespace": true,
+  "disallowKeywordsOnNewLine": [
+    "else"
+  ],
+  "requireLineFeedAtFileEnd": true,
+  "disallowYodaConditions": true,
+  "disallowNewlineBeforeBlockStatements": true,
   "validateQuoteMarks": {
     "escape": true,
     "mark": "'"
-  }
+  },
+  "validateIndentation": 2
 }

--- a/js/eventemitter.js
+++ b/js/eventemitter.js
@@ -25,7 +25,7 @@ define(function() {
    *        Bind all public methods of EventEmitter to
    *        the aObjectToDecorate object.
    */
-  EventEmitter.decorate = function EventEmitter_decorate (aObjectToDecorate) {
+  EventEmitter.decorate = function EventEmitter_decorate(aObjectToDecorate) {
     let emitter = new EventEmitter();
     aObjectToDecorate.on = emitter.on.bind(emitter);
     aObjectToDecorate.off = emitter.off.bind(emitter);

--- a/js/keybindings.js
+++ b/js/keybindings.js
@@ -39,7 +39,7 @@ define(function() {
       } else {
         e.key = key;
       }
-      allKeyBindings.push({event:e,func:func});
+      allKeyBindings.push({event: e, func: func});
     }
   }
 

--- a/js/sidetabs.js
+++ b/js/sidetabs.js
@@ -53,20 +53,20 @@ require(['js/tabiframedeck'], function(TabIframeDeck) {
     button.className = 'close-button';
 
     button.onmouseup = (event) => {
-      if(event.button == 0) {
+      if (event.button == 0) {
         event.stopPropagation();
         TabIframeDeck.remove(tabIframe);
       }
     };
 
     hbox.onmousedown = (event) => {
-      if(event.button == 0) {
+      if (event.button == 0) {
         TabIframeDeck.select(tabIframe);
       }
     };
 
     hbox.onmouseup = (event) => {
-      if(event.button == 1) {
+      if (event.button == 1) {
         event.stopPropagation();
         TabIframeDeck.remove(tabIframe);
       }

--- a/js/tabiframe.js
+++ b/js/tabiframe.js
@@ -140,37 +140,37 @@ define(['js/eventemitter'], function(EventEmitter) {
   };
 
   Object.defineProperty(tabIframeProto, 'loading', {
-    get: function () {
+    get: function() {
       return this._loading;
     }
   });
 
   Object.defineProperty(tabIframeProto, 'title', {
-    get: function () {
+    get: function() {
       return this._title;
     }
   });
 
   Object.defineProperty(tabIframeProto, 'location', {
-    get: function () {
+    get: function() {
       return this._location;
     }
   });
 
   Object.defineProperty(tabIframeProto, 'favicon', {
-    get: function () {
+    get: function() {
       return this._favicon;
     }
   });
 
   Object.defineProperty(tabIframeProto, 'securityState', {
-    get: function () {
+    get: function() {
       return this._securityState;
     }
   });
 
   Object.defineProperty(tabIframeProto, 'securityExtendedValidation', {
-    get: function () {
+    get: function() {
       return this._securityExtendedValidation;
     }
   });
@@ -208,7 +208,7 @@ define(['js/eventemitter'], function(EventEmitter) {
   tabIframeProto.handleEvent = function(e) {
     let somethingChanged = true;
 
-    switch(e.type) {
+    switch (e.type) {
       case 'mozbrowserloadstart':
         this._clearTabData();
         this._loading = true;
@@ -241,6 +241,6 @@ define(['js/eventemitter'], function(EventEmitter) {
     this.emit(e.type, e, this);
   };
 
-  let TabIframe =document.registerElement('tab-iframe', {prototype: tabIframeProto});
+  let TabIframe = document.registerElement('tab-iframe', {prototype: tabIframeProto});
   return TabIframe;
 });

--- a/js/tabiframedeck.js
+++ b/js/tabiframedeck.js
@@ -35,7 +35,7 @@ define(['js/tabiframe', 'js/eventemitter', 'js/keybindings'],
       let session = [];
       try {
         session = JSON.parse(window.localStorage.session);
-      } catch(e) {}
+      } catch (e) {}
 
       if (Array.isArray(session) && session.length > 0) {
         for (let url of session) {
@@ -47,7 +47,7 @@ define(['js/tabiframe', 'js/eventemitter', 'js/keybindings'],
     },
 
     onMozBrowserOpenWindow: function(type, event) {
-      TabIframeDeck.add({url:event.detail.url});
+      TabIframeDeck.add({url: event.detail.url});
     },
 
     add: function(options={}) {
@@ -185,7 +185,7 @@ define(['js/tabiframe', 'js/eventemitter', 'js/keybindings'],
 
   if (window.OS == 'linux' || window.OS == 'windows') {
     RegisterKeyBindings(
-      ['Ctrl',          't',          () => TabIframeDeck.add({select:true})],
+      ['Ctrl',          't',          () => TabIframeDeck.add({select: true})],
       ['Ctrl',          'r',          () => TabIframeDeck.getSelected().reload()],
       ['Alt',           'Left',       () => TabIframeDeck.getSelected().goBack()],
       ['Alt',           'Right',      () => TabIframeDeck.getSelected().goForward()],
@@ -199,7 +199,7 @@ define(['js/tabiframe', 'js/eventemitter', 'js/keybindings'],
 
   if (window.OS == 'osx') {
     RegisterKeyBindings(
-      ['Cmd',       't',          () => TabIframeDeck.add({select:true})],
+      ['Cmd',       't',          () => TabIframeDeck.add({select: true})],
       ['Cmd',       'r',          () => TabIframeDeck.getSelected().reload()],
       ['Cmd',       'Left',       () => TabIframeDeck.getSelected().goBack()],
       ['Cmd',       'Right',      () => TabIframeDeck.getSelected().goForward()],

--- a/js/tabstrip.js
+++ b/js/tabstrip.js
@@ -55,20 +55,20 @@ require(['js/tabiframedeck'], function(TabIframeDeck) {
     button.className = 'close-button';
 
     button.onmouseup = (event) => {
-      if(event.button == 0) {
+      if (event.button == 0) {
         event.stopPropagation();
         TabIframeDeck.remove(tabIframe);
       }
     };
 
     hbox.onmousedown = (event) => {
-      if(event.button == 0) {
+      if (event.button == 0) {
         TabIframeDeck.select(tabIframe);
       }
     };
 
     hbox.onmouseup = (event) => {
-      if(event.button == 1) {
+      if (event.button == 1) {
         event.stopPropagation();
         TabIframeDeck.remove(tabIframe);
       }
@@ -224,18 +224,18 @@ require(['js/tabiframedeck'], function(TabIframeDeck) {
     let curveHoverGradientEnd = style.getPropertyValue('--curve-hover-gradient-end');
 
     let c1 = document.createElement('canvas');
-        c1.id = 'canvas-tab-selected';
-        c1.hidden = true;
-        c1.width = 3 * 28;
-        c1.height = 28;
+    c1.id = 'canvas-tab-selected';
+    c1.hidden = true;
+    c1.width = 3 * 28;
+    c1.height = 28;
     drawBackgroundTab(c1, curveGradientStart, curveGradientEnd, curveBorder);
     document.body.appendChild(c1);
 
     let c2 = document.createElement('canvas');
-        c2.id = 'canvas-tab-hover';
-        c2.hidden = true;
-        c2.width = 3 * 28;
-        c2.height = 28;
+    c2.id = 'canvas-tab-hover';
+    c2.hidden = true;
+    c2.width = 3 * 28;
+    c2.height = 28;
     drawBackgroundTab(c2, curveHoverGradientStart, curveHoverGradientEnd, curveHoverBorder);
     document.body.appendChild(c2);
 
@@ -247,28 +247,28 @@ require(['js/tabiframedeck'], function(TabIframeDeck) {
       let r = canvas.height;
       ctx.save();
       ctx.beginPath();
-      drawCurve(ctx,r);
+      drawCurve(ctx, r);
       ctx.lineTo(3 * r, r);
       ctx.lineTo(0, r);
       ctx.closePath();
       ctx.clip();
 
       // draw background
-      let lingrad = ctx.createLinearGradient(0,0,0,r);
+      let lingrad = ctx.createLinearGradient(0, 0, 0, r);
       lingrad.addColorStop(0, bg1);
       lingrad.addColorStop(1, bg2);
       ctx.fillStyle = lingrad;
-      ctx.fillRect(0,0,3*r,r);
+      ctx.fillRect(0, 0, 3 * r, r);
 
       // draw border
       ctx.restore();
       ctx.beginPath();
-      drawCurve(ctx,r);
+      drawCurve(ctx, r);
       ctx.strokeStyle = borderColor;
       ctx.stroke();
     }
 
-    function drawCurve(ctx,r) {
+    function drawCurve(ctx, r) {
       let firstLine = 1 / window.devicePixelRatio;
       ctx.moveTo(r * 0, r * 0.984);
       ctx.bezierCurveTo(r * 0.27082458, r * 0.95840561,

--- a/js/urlhelper.js
+++ b/js/urlhelper.js
@@ -67,5 +67,5 @@ define(function() {
     }
   };
 
-return UrlHelper;
+  return UrlHelper;
 });


### PR DESCRIPTION
Hi @paulrouget,

could you review these changes? I tried to follow your style as much as possible and fine-tuned the `.jscsrc` accordingly. It worked very well with just a few changes.

I did _not_ made a decision about disallowing/requiring trailing commas and didn't set a maximum line length.

I would like to use [`requireSpaceBeforeObjectValues`](https://github.com/jscs-dev/node-jscs#requirespacebeforeobjectvalues) in the future, but it looks like there is a bug with `esnext` enabled: https://github.com/jscs-dev/node-jscs/issues/840.
