### PR TITLE
Only set urlbar to location, when we have a location URL

### DIFF
--- a/js/navbar.js
+++ b/js/navbar.js
@@ -169,8 +169,8 @@ function(UrlHelper, TabIframeDeck, RegisterKeyBindings) {
 
     if (tabIframe.userInput) {
       urlinput.value = tabIframe.userInput;
-    } else {
-      urlinput.value = tabIframe.location
+    } else if (tabIframe.location) {
+      urlinput.value = tabIframe.location;
     }
 
     if (!window.IS_PRIVILEGED) {


### PR DESCRIPTION
This prevents the empty urlbar flash when reloading a page.
