### PR TITLE
Trim http and trailing slash from URLs

### DIFF
--- a/js/navbar.js
+++ b/js/navbar.js
@@ -170,7 +170,7 @@ function(UrlHelper, TabIframeDeck, RegisterKeyBindings) {
     if (tabIframe.userInput) {
       urlinput.value = tabIframe.userInput;
     } else if (tabIframe.location) {
-      urlinput.value = tabIframe.location;
+      urlinput.value = UrlHelper.trim(tabIframe.location);
     } else if (eventName === null) {
       urlinput.value = '';
     }

--- a/js/urlhelper.js
+++ b/js/urlhelper.js
@@ -64,6 +64,18 @@ define(function() {
       }
       this.urlValidate.setAttribute('value', str);
       return !this.urlValidate.validity.valid;
+    },
+
+    trim: function(input) {
+      // remove single trailing slash for http/https/ftp URLs
+      let url = input.replace(/^((?:http|https|ftp):\/\/[^/]+)\/$/, '$1');
+
+      // remove http://
+      if (!url.startsWith('http://')) {
+        return url;
+      }
+
+      return url.substring(7);
     }
   };
 


### PR DESCRIPTION
Firefox has some additional code that trimming the URL doesn't change behavior, but I don't think we need that right now.
