### PR TITLE
adding requirejs as a dependency installed via npm

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -40,6 +40,8 @@ To run tests manually you need to install our dependencies _once_ after cloning 
 npm install
 ```
 
+You probably already did this if you followed the `README.md` instructions.
+
 After installing the dependencies you can trigger the tests with the following command:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -20,17 +20,12 @@ And eventually be able to render Firefox Desktop with [Servo](https://github.com
 
 **Setup**
 
-1. Clone this repository somewhere on your computer using `git clone --recursive https://github.com/paulrouget/firefox.html`
-2. Download HTMLRunner runtime: http://people.mozilla.org/~prouget/htmlrunner/ (package is named `firefox-XX.XX`);
-3. Run HTMLRunner runtime (binary name is `firefox`);
-4. HTMLRunner will ask (only once) the location of the `firefox.html` directory you cloned in step 1;
-5. You should now see the browser running.
-
-Note: If you have cloned without `--recursive`, you may find out that `lib/require.js` is empty. To fix this:
-
-````
-git submodule update --init
-````
+1. Clone this repository somewhere on your computer using `git clone https://github.com/paulrouget/firefox.html`
+2. Install all dependencies using `npm install`
+3. Download HTMLRunner runtime: http://people.mozilla.org/~prouget/htmlrunner/ (package is named `firefox-XX.XX`);
+4. Run HTMLRunner runtime (binary name is `firefox`);
+5. HTMLRunner will ask (only once) the location of the `firefox.html` directory you cloned in step 1;
+6. You should now see the browser running.
 
 **Contribute**
 

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 
     <!-- Module handling -->
     <!-- All further JS code is loaded from javascript -->
-    <script data-main='app' src='lib/require.js/require.js'
+    <script data-main='app' src='node_modules/requirejs/require.js'
       type='text/javascript' defer='defer'></script>
     <script src='js/sanitycheck.js'></script>
   </head>

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,7 +1,0 @@
-This directory contains external dependencies.
-
-If, after cloning the repository, this directory does not contain subdirectories,
-you need to call
-````
-git submodule update --init
-````

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   },
   "devDependencies": {
     "jscs": "^1.8.1"
+  },
+  "dependencies": {
+    "requirejs": "^2.1.15"
   }
 }


### PR DESCRIPTION
Hi @paulrouget,

I've added `require.js` a a dependency to the `package.json` and remove the Git submodule. I've changed the `README.md` accordingly.

I guess this is just a temporary dependency as we will use ES6 modules in the future, right? Even if `npm` is [really popular](http://blog.npmjs.org/post/101775448305/npm-and-front-end-packaging) for front-end packages nowadays there is still a mismatch sometimes. If you look into [requirejs-bower](https://github.com/jrburke/requirejs-bower/blob/master/bower.json#L9) and [requirejs-npm](https://github.com/requirejs/requirejs-npm/blob/master/requirejs/package.json#L21) you'll see that they use different `"main"` files. This is probably wrong ([issue](https://github.com/requirejs/requirejs-npm/issues/5)). This doesn't affect us because we load `require.js` directly from the file system and not with a build step or module loading mechanism. It isn't a big deal, but you should be aware of it, especially if we want to add other dependencies in the future.