### PR TITLE
Switch from HTMLRunner to Firebox

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,11 @@
     "url": "http://paulrouget.com/"
   },
   "scripts": {
-    "test": "jscs ./"
+    "test": "jscs ./",
+    "start": "open -n -a FirefoxNightly --args -app $(pwd)/node_modules/firebox/application.ini $(pwd)/manifest.webapp"
   },
   "devDependencies": {
-    "jscs": "^1.8.1"
+    "jscs": "^1.8.1",
+    "firebox": "git://github.com/Gozala/firebox.git#html-runner"
   }
 }


### PR DESCRIPTION
While this looks like two liner it is a very significant change. I've created [firebox](https://github.com/gozala/firebox) project branch that integrates ideas from HTMLRunner, while providing additional benefits:

1. Hacking on firebox does not require building firefox, just edit & reload. This will make it a lot easier for everyone to hack on the runtime.
2. Now `npm install` sep will take care of installing everything, all you would need to do is run `npm start` to start hacking.
3. Firebox does not needs to rebuild .zip file on reload as it actually loads code from the directory where app code is developed.
4. Firebox can load apps from the web, I'm able to run firefox.html by running `open -n -a FirefoxNightly --args -app $(pwd)/node_modules/firebox/application.ini http://localhost/\~gozala/Projects/firefox.html/manifest.webapp`.
5. Firebox does not bound to any specific APP and you could run different applications with it.


That being said, I don't know what would be an equivalent of `open` command so current `npm start` will only work on mac, but it should be possible to fix that.